### PR TITLE
feat: FluCalendarDatePicker emits selectedDate signal when date is picked

### DIFF
--- a/FluControls/FluCalendarDatePicker.h
+++ b/FluControls/FluCalendarDatePicker.h
@@ -44,6 +44,8 @@ class FluCalendarDatePicker : public QPushButton
             m_textButton->setText(dateText);
             LOG_DEBUG << date;
             m_calendarView->hide();
+
+            emit selectedDate(date);
         });
 
         connect(this, &FluCalendarDatePicker::clicked, [=]() { onClicked(); });
@@ -68,6 +70,9 @@ class FluCalendarDatePicker : public QPushButton
 
         emit m_calendarView->selectedDate(date);
     }
+
+  signals:
+    void selectedDate(QDate date);
 
   public slots:
     void onClicked()


### PR DESCRIPTION
The `FluCalendarDatePicker::selectedDate` signal is emitted when either `FluCalendarDatePicker::setCurDate` or `FluCalendarView::setCurDate` is called. This signal is intended for external connections and can be used to perform additional actions such as updating the database.

Please note that calling `FluCalendarDatePicker::setCurDate` triggers `FluCalendarView::selectedDate`, which in turn triggers `FluCalendarDatePicker::selectedDate`. If this chain reaction is not desirable, you can call `FluCalendarDatePicker::blockSignal(true)` to prevent it.