### PR TITLE
fix: allow mouse events to pass through the wrapper widget

### DIFF
--- a/FluControls/FluTextEditWrap.h
+++ b/FluControls/FluTextEditWrap.h
@@ -13,6 +13,7 @@ class FluTextEditWrap : public QWidget
     FluTextEditWrap(FluTextEdit* parent = nullptr) : QWidget(parent), m_textEdit(parent)
     {
         setAttribute(Qt::WA_TranslucentBackground);
+        setAttribute(Qt::WA_TransparentForMouseEvents);
         if (parent != nullptr)
             parent->installEventFilter(this);
     }


### PR DESCRIPTION
Occasionally, the wrapper widget interferes with FluTextEdit's mouse events, preventing text within it from being selectable by mouse.