### PR TITLE
feat: `FluMenu` and `FluDropDownButton` support the `actionTriggered` signal

### DIFF
--- a/FluControls/FluDropDownButton.h
+++ b/FluControls/FluDropDownButton.h
@@ -54,6 +54,7 @@ class FluDropDownButton : public FluWidget
             m_menu->exec(leftBottomPos);
             //  m_menu->show();
         });
+        connect(m_menu, &FluMenu::actionTriggered, [=](QAction* action) { setText(action->text()); });
 
         FluStyleSheetUitls::setQssByFileName("../StyleSheet/light/FluDropDownButton.qss", this);
     }

--- a/FluControls/FluMenu.cpp
+++ b/FluControls/FluMenu.cpp
@@ -23,6 +23,8 @@ FluMenu::FluMenu(QWidget* parent /*= nullptr*/) : QMenu(parent)
 void FluMenu::addAction(FluAction* action)
 {
     QMenu::addAction(action);
+    connect(action, &QAction::triggered, [=]() { emit actionTriggered(action); });
+
     // connect(action, &QAction::hovered, [=]() { LOG_DEBUG << "hovered"; });
 
     // connect(action, &QAction::ho, [=]() {

--- a/FluControls/FluMenu.h
+++ b/FluControls/FluMenu.h
@@ -16,6 +16,9 @@ class FluMenu : public QMenu
 
     void paintEvent(QPaintEvent* event);
 
+  signals:
+    void actionTriggered(QAction* action);
+
   public slots:
     void onThemeChanged();
 };


### PR DESCRIPTION
- `FluMenu` now emits the `actionTriggered` signal whenever an action is activated.
- `FluDropDownButton` listens for the `actionTriggered` signal and refreshes its text accordingly.