### PR TITLE
feat: `FluComboBoxEx` supports `setIndex`

### DIFF
--- a/FluControls/FluComboBoxEx.cpp
+++ b/FluControls/FluComboBoxEx.cpp
@@ -93,8 +93,8 @@ void FluComboBoxEx::setIndex(int index)
     }
 
     m_textBtn->setText(text);
-    emit currentTextChanged(text);
     emit currentIndexChanged(index);
+    emit currentTextChanged(text);
 }
 
 void FluComboBoxEx::setText(QString text)

--- a/FluControls/FluComboBoxEx.cpp
+++ b/FluControls/FluComboBoxEx.cpp
@@ -78,6 +78,25 @@ void FluComboBoxEx::setIcon(FluAwesomeType type)
     m_textBtn->setIcon(FluIconUtils::getFluentIconPixmap(type, FluThemeUtils::getUtils()->getTheme()));
 }
 
+void FluComboBoxEx::setIndex(int index)
+{
+    if (index < -1 || index >= m_menu->actions().size())
+    {
+        return;
+    }
+
+    QString text = "";
+    if (index != -1)
+    {
+        auto action = m_menu->actions()[index];
+        text = action->text();
+    }
+
+    m_textBtn->setText(text);
+    emit currentTextChanged(text);
+    emit currentIndexChanged(index);
+}
+
 void FluComboBoxEx::setText(QString text)
 {
     m_textBtn->setText(text);

--- a/FluControls/FluComboBoxEx.h
+++ b/FluControls/FluComboBoxEx.h
@@ -20,6 +20,8 @@ class FluComboBoxEx : public FluWidget
 
     void setIcon(FluAwesomeType type);
 
+    void setIndex(int index);
+
     void setText(QString text);
 
     void addItem(QString text);


### PR DESCRIPTION
Please note that calling `FluComboBoxEx::setIndex` triggers both `FluComboBoxEx::currentIndexChanged` and `FluComboBoxEx::currentTextChanged` **almost simultaneously**. It is important to note that `FluComboBoxEx::currentIndexChanged` is emitted slightly earlier than `FluComboBoxEx::currentTextChanged`. Therefore, when these two signals are both connected, it is better to handle your logic in a careful way to avoid potential issues.